### PR TITLE
Level1v1Audio

### DIFF
--- a/Assets/Scenes/Level1v1Audio.unity
+++ b/Assets/Scenes/Level1v1Audio.unity
@@ -1,0 +1,15255 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 1
+    m_PVRFilteringGaussRadiusAO: 1
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &16832507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 16832509}
+  - component: {fileID: 16832508}
+  m_Layer: 0
+  m_Name: Ice_Top_26_small_R_0001 (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &16832508
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16832507}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: d3724c7a7e4fc2848946525a26489098, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &16832509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 16832507}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 75.86269, y: -2.4997225, z: 2.5791798}
+  m_LocalScale: {x: -10.389, y: 16.242, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &36354424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 36354425}
+  - component: {fileID: 36354426}
+  m_Layer: 6
+  m_Name: Ground1 (7)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &36354425
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36354424}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 8.31, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &36354426
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36354424}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1001 &104387451
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 104387453}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &104387452 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 104387451}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &104387453
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 104387452}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &133092203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 133092205}
+  - component: {fileID: 133092204}
+  m_Layer: 0
+  m_Name: Ice_Top_26_big_R_0001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &133092204
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133092203}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 2335c684b118c804290e36fa1f3d8c3c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &133092205
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133092203}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 15.149492, y: -4.2616224, z: 2.5791798}
+  m_LocalScale: {x: 10.454, y: 12.678244, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &302439601
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 302439603}
+  - component: {fileID: 302439602}
+  m_Layer: 0
+  m_Name: Ice_Bot_26_big_R_0001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &302439602
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302439601}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: 713e7267c5e741741af88791782f6778, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &302439603
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 302439601}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -15.967308, y: -2.1706223, z: 2.5791798}
+  m_LocalScale: {x: 10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &324063200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 324063201}
+  m_Layer: 0
+  m_Name: Room1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &324063201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 324063200}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1519090610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &352418665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 352418666}
+  - component: {fileID: 352418667}
+  m_Layer: 6
+  m_Name: Ground1
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &352418666
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 352418665}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -5.229343, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &352418667
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 352418665}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1001 &388981801
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 388981803}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &388981802 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 388981801}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &388981803
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 388981802}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &392380338
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 392380339}
+  - component: {fileID: 392380341}
+  - component: {fileID: 392380340}
+  m_Layer: 5
+  m_Name: PausedTitle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &392380339
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392380338}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1990326612}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.00048685, y: 119}
+  m_SizeDelta: {x: 216.18, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &392380340
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392380338}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Game Paused
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &392380341
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 392380338}
+  m_CullTransparentMesh: 1
+--- !u!1 &441847662
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 441847663}
+  - component: {fileID: 441847665}
+  - component: {fileID: 441847664}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &441847663
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441847662}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 840750267}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &441847664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441847662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Resume
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &441847665
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441847662}
+  m_CullTransparentMesh: 1
+--- !u!1001 &468103844
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380089285432070438, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.1030548
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380089285432070438, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.11152735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 13.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 468103846}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &468103845 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 468103844}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &468103846
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 468103845}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1001 &523421564
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380089285432070438, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062306
+      objectReference: {fileID: 0}
+    - target: {fileID: 4380089285432070438, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09115291
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1001 &545146432
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 44.43006
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.221345
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932666604899267738, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: projectileMaxDistance
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6427233763794309383, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_Name
+      value: Enemy2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+--- !u!1 &594608851
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 594608853}
+  - component: {fileID: 594608852}
+  m_Layer: 6
+  m_Name: Ground
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &594608852
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594608851}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 4.1767673, y: -0.08761686}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 21.68589, y: 2.427794}
+  m_EdgeRadius: 0
+--- !u!4 &594608853
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 594608851}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.97, y: -4.83, z: -2.528701}
+  m_LocalScale: {x: 0.89393, y: 0.89393, z: 0.89393}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 352418666}
+  - {fileID: 1664511229}
+  - {fileID: 678556803}
+  - {fileID: 1882207026}
+  - {fileID: 36354425}
+  - {fileID: 2009565554}
+  - {fileID: 727611622}
+  - {fileID: 788234879}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &596899055
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 25.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 596899057}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &596899056 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 596899055}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &596899057
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 596899056}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1001 &638369958
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 26.16005
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.673244
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673483294832375654, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4932666604899267738, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: projectileMaxDistance
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 6427233763794309383, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+      propertyPath: m_Name
+      value: Enemy2 (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 75e0eb1ae0f8fd240beeb230a0396436, type: 3}
+--- !u!1001 &669912634
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28.33
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 13.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 669912636}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &669912635 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 669912634}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &669912636
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 669912635}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &678556802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 678556803}
+  - component: {fileID: 678556804}
+  m_Layer: 6
+  m_Name: Ground1 (5)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &678556803
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 678556802}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 10.93, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &678556804
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 678556802}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &680013819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 680013820}
+  - component: {fileID: 680013821}
+  m_Layer: 0
+  m_Name: Ice_Bot_26_big_R_0001 (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &680013820
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 680013819}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 60.463493, y: 17.87938, z: 2.5791798}
+  m_LocalScale: {x: -10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &680013821
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 680013819}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: 713e7267c5e741741af88791782f6778, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &727611621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 727611622}
+  - component: {fileID: 727611623}
+  m_Layer: 6
+  m_Name: Ground1 (3)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &727611622
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 727611621}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.940265, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &727611623
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 727611621}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &743183542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 743183543}
+  - component: {fileID: 743183545}
+  - component: {fileID: 743183544}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &743183543
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 743183542}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 808651317}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &743183544
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 743183542}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Exit
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &743183545
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 743183542}
+  m_CullTransparentMesh: 1
+--- !u!1 &788234878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 788234879}
+  - component: {fileID: 788234880}
+  m_Layer: 6
+  m_Name: Ground1 (1)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &788234879
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788234878}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.510289, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &788234880
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788234878}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &803293036
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 803293037}
+  - component: {fileID: 803293039}
+  - component: {fileID: 803293038}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &803293037
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803293036}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1458788515}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &803293038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803293036}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Restart
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &803293039
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 803293036}
+  m_CullTransparentMesh: 1
+--- !u!1 &808651316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 808651317}
+  - component: {fileID: 808651320}
+  - component: {fileID: 808651319}
+  - component: {fileID: 808651318}
+  m_Layer: 5
+  m_Name: Exit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &808651317
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808651316}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 743183543}
+  m_Father: {fileID: 1990326612}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000010192, y: -98}
+  m_SizeDelta: {x: 216.1837, y: 37.8396}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &808651318
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808651316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.8616352, g: 0.32243574, b: 0.32243574, a: 1}
+    m_PressedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 808651319}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1098634954}
+        m_TargetAssemblyTypeName: PauseMenu, Assembly-CSharp
+        m_MethodName: ExitGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &808651319
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808651316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &808651320
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808651316}
+  m_CullTransparentMesh: 1
+--- !u!1 &816364922
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 816364924}
+  - component: {fileID: 816364923}
+  - component: {fileID: 816364925}
+  m_Layer: 0
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &816364923
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816364922}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -20
+  m_Sprite: {fileID: 21300000, guid: c267d2a67c862c74d868d358b4881252, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 17.46, y: 12.33}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &816364924
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816364922}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.05, y: 3.4, z: 0.019290056}
+  m_LocalScale: {x: 2.034118, y: 2.034118, z: 2.034118}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &816364925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 816364922}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: acc851a60974a4335b64a1560878f36c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  cameraTransform: {fileID: 1779223840}
+--- !u!1 &840750266
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 840750267}
+  - component: {fileID: 840750270}
+  - component: {fileID: 840750269}
+  - component: {fileID: 840750268}
+  m_Layer: 5
+  m_Name: ResumeButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &840750267
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840750266}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 441847663}
+  m_Father: {fileID: 1990326612}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000010192, y: 42.0802}
+  m_SizeDelta: {x: 216.1837, y: 37.8396}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &840750268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840750266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.44316435, g: 0.8490566, b: 0.41918826, a: 1}
+    m_PressedColor: {r: 0.14499354, g: 1, b: 0, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 840750269}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1098634954}
+        m_TargetAssemblyTypeName: PauseMenu, Assembly-CSharp
+        m_MethodName: ResumeGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &840750269
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840750266}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &840750270
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 840750266}
+  m_CullTransparentMesh: 1
+--- !u!1 &896794830
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 896794832}
+  - component: {fileID: 896794831}
+  m_Layer: 0
+  m_Name: Ice_platform_0001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &896794831
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896794830}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -3
+  m_Sprite: {fileID: 21300000, guid: 3169412c48ef6d04482e2ed92f259bc3, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &896794832
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896794830}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.1626916, y: 4.079377, z: 2.5791798}
+  m_LocalScale: {x: 10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &898002497
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080085863366972330, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_Name
+      value: Enemy1 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 44.106697
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22.820375
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+--- !u!1 &961005061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 961005065}
+  - component: {fileID: 961005064}
+  - component: {fileID: 961005063}
+  - component: {fileID: 961005062}
+  m_Layer: 0
+  m_Name: AudioManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &961005062
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961005061}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!82 &961005063
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961005061}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &961005064
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961005061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 865d5e81ab1eb4c52b67922e5e091fc6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sfxSource: {fileID: 961005063}
+  ambientSource: {fileID: 961005062}
+  ambientClip: {fileID: 8300000, guid: 64133cd11ac38412c96ae2ee96aa4ac8, type: 3}
+  shootClip: {fileID: 8300000, guid: d096bc267e25e4a9ba29eb9844b108dd, type: 3}
+  breakClip: {fileID: 8300000, guid: cbe9039a8ad114526b6deb0fb9b6495d, type: 3}
+  footStepsClip: {fileID: 8300000, guid: a948133482bd9461cbcb85c1b36c59b7, type: 3}
+  gameOverClip: {fileID: 8300000, guid: c00343968e27244bba50bdda6a33049a, type: 3}
+--- !u!4 &961005065
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961005061}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &963250250
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080085863366972330, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_Name
+      value: Enemy1 (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 40.5497
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 26.781572
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+--- !u!1 &974160789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 974160795}
+  - component: {fileID: 974160794}
+  - component: {fileID: 974160793}
+  - component: {fileID: 974160792}
+  - component: {fileID: 974160791}
+  - component: {fileID: 974160790}
+  m_Layer: 9
+  m_Name: Checkpoint Hitbox
+  m_TagString: checkpoint
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &974160790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974160789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 257a73ffc2b0447a8b7dc8e8776458cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &974160791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974160789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 628a72c01b5864fb09cfbfd76f21dbae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 4
+  moveDistance: 17
+--- !u!50 &974160792
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974160789}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!61 &974160793
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974160789}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!212 &974160794
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974160789}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &974160795
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974160789}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 28.46, y: 35.37, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &998851726
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 998851728}
+  - component: {fileID: 998851727}
+  m_Layer: 0
+  m_Name: TimeManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &998851727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 998851726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2865bb3c0cc79413cbc29873ad915c80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  timeRemaining: 75
+  timerText: {fileID: 1665319722}
+  checkpoint: {fileID: 974160789}
+  nextSceneName: Level2v2Audio
+--- !u!4 &998851728
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 998851726}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 93.082726, y: 192.59607, z: -1.4757178}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1050653820
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080085863366972330, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_Name
+      value: Enemy1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.3379345
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4.7120476
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+--- !u!1001 &1053036498
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 21.46
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1053036500}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &1053036499 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 1053036498}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &1053036500
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1053036499}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &1071931635
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1071931639}
+  - component: {fileID: 1071931638}
+  - component: {fileID: 1071931637}
+  - component: {fileID: 1071931636}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1071931636
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071931635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1071931637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071931635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1071931638
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071931635}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1071931639
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1071931635}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1990326612}
+  - {fileID: 1098634953}
+  - {fileID: 1487661379}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1001 &1081612221
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.36
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1081612223}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &1081612222 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 1081612221}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &1081612223
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1081612222}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &1098634952
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1098634953}
+  - component: {fileID: 1098634954}
+  m_Layer: 5
+  m_Name: PauseManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1098634953
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098634952}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1071931639}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1098634954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1098634952}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f15b408cb356e448ba682dc85bef467, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  PauseMenuUI: {fileID: 1990326611}
+--- !u!1 &1118944965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1118944967}
+  - component: {fileID: 1118944966}
+  m_Layer: 0
+  m_Name: Ice_Top_26_small_R_0001 (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1118944966
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1118944965}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: d3724c7a7e4fc2848946525a26489098, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1118944967
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1118944965}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 16.033493, y: 37.779377, z: 2.5791798}
+  m_LocalScale: {x: 13.941999, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1122101262
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 6.76
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1122101264}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &1122101263 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 1122101262}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &1122101264
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1122101263}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &1267993512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1267993514}
+  - component: {fileID: 1267993513}
+  m_Layer: 0
+  m_Name: Ice_Bot_26_big_R_0001 (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1267993513
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267993512}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: 713e7267c5e741741af88791782f6778, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1267993514
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267993512}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3.9526916, y: 17.87938, z: 2.5791798}
+  m_LocalScale: {x: 10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1386625551
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.23
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1386625553}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &1386625552 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 1386625551}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &1386625553
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1386625552}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &1417105288 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4766387216651809969, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+  m_PrefabInstance: {fileID: 1425040208}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1425040208
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 178539560283458751, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Name
+      value: Player_v3
+      objectReference: {fileID: 0}
+    - target: {fileID: 178539560283458751, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 922639656492101010, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.86
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0500509
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2691886590690306991, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4766387216651809969, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4766387216651809969, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5097494752517582546, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: inputHandler
+      value: 
+      objectReference: {fileID: 2127150266}
+    - target: {fileID: 6756101750911334379, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8749598494257503653, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.45
+      objectReference: {fileID: 0}
+    - target: {fileID: 8761938571733777841, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8807397667818018024, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 178539560283458751, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1425040210}
+  m_SourcePrefab: {fileID: 100100000, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+--- !u!1 &1425040209 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 178539560283458751, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+  m_PrefabInstance: {fileID: 1425040208}
+  m_PrefabAsset: {fileID: 0}
+--- !u!70 &1425040210
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425040209}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 6200000, guid: 093e5b5a7f09af24693ea0e7027598bb, type: 2}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 1.8930676, y: 2.86}
+  m_Direction: 0
+--- !u!114 &1425040211 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9213901320047484148, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+  m_PrefabInstance: {fileID: 1425040208}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425040209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e2910c9b917989243ac0bd0cf1f3ec3d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1425040216 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1667166313818279941, guid: 58b612dd42c3dc94e995935e122976fe, type: 3}
+  m_PrefabInstance: {fileID: 1425040208}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1458788514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1458788515}
+  - component: {fileID: 1458788518}
+  - component: {fileID: 1458788517}
+  - component: {fileID: 1458788516}
+  m_Layer: 5
+  m_Name: Restart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1458788515
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458788514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 803293037}
+  m_Father: {fileID: 1990326612}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.000010192, y: -28}
+  m_SizeDelta: {x: 216.1837, y: 37.8396}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1458788516
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458788514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1458788517}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1098634954}
+        m_TargetAssemblyTypeName: PauseMenu, Assembly-CSharp
+        m_MethodName: RestartGame
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1458788517
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458788514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1458788518
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458788514}
+  m_CullTransparentMesh: 1
+--- !u!1 &1476134715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1476134716}
+  - component: {fileID: 1476134717}
+  m_Layer: 0
+  m_Name: Ice_Bot_26_big_R_0001 (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1476134716
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1476134715}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 80.38349, y: -2.1706228, z: 2.5791798}
+  m_LocalScale: {x: -10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1476134717
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1476134715}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: 713e7267c5e741741af88791782f6778, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1487661378
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1487661379}
+  - component: {fileID: 1487661381}
+  - component: {fileID: 1487661380}
+  m_Layer: 5
+  m_Name: TimerPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1487661379
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1487661378}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1665319724}
+  m_Father: {fileID: 1071931639}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 233}
+  m_SizeDelta: {x: 320, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1487661380
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1487661378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.98039216}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1487661381
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1487661378}
+  m_CullTransparentMesh: 1
+--- !u!1 &1494014522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1494014523}
+  - component: {fileID: 1494014524}
+  m_Layer: 0
+  m_Name: Ice_Bot_spikes_0001 (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1494014523
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494014522}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 48.44619, y: 17.87938, z: 2.5791798}
+  m_LocalScale: {x: -14.215557, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1494014524
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494014522}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: d284f359f900b004aacb1ec1ebfcc356, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1512006285
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1512006286}
+  - component: {fileID: 1512006287}
+  m_Layer: 0
+  m_Name: Ice_Bot_26_big_R_0001 (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1512006286
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512006285}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 70.42349, y: 7.8093777, z: 2.5791798}
+  m_LocalScale: {x: -10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1512006287
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512006285}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: 713e7267c5e741741af88791782f6778, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1519090609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1519090610}
+  m_Layer: 0
+  m_Name: Level
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1519090610
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519090609}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 324063201}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1528382388
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1528382389}
+  - component: {fileID: 1528382391}
+  - component: {fileID: 1528382390}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1528382389
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1528382388}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1990326612}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.59000003, y: 0.5}
+  m_AnchorMax: {x: 0.59000003, y: 0.5}
+  m_AnchoredPosition: {x: -9, y: -0.6534004}
+  m_SizeDelta: {x: 277.69702, y: 343.02692}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1528382390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1528382388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1528382391
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1528382388}
+  m_CullTransparentMesh: 1
+--- !u!1 &1548924849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1548924851}
+  - component: {fileID: 1548924850}
+  m_Layer: 0
+  m_Name: Ice_Top_26_big_R_0001 (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1548924850
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548924849}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 2335c684b118c804290e36fa1f3d8c3c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1548924851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548924849}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 51.56269, y: -0.60062265, z: 2.5791798}
+  m_LocalScale: {x: -21.36901, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1556547811
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080085863366972330, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_Name
+      value: Enemy1 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.312838
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22.901217
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+--- !u!1 &1569588819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1569588821}
+  - component: {fileID: 1569588820}
+  m_Layer: 0
+  m_Name: Ice_Bot_26_big_R_0001 (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1569588820
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569588819}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: 713e7267c5e741741af88791782f6778, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1569588821
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1569588819}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6.007308, y: 7.8093777, z: 2.5791798}
+  m_LocalScale: {x: 10, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1584595672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1584595674}
+  - component: {fileID: 1584595673}
+  - component: {fileID: 1584595675}
+  m_Layer: 0
+  m_Name: Ice_Top_26_small_R_0001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1584595673
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1584595672}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: d3724c7a7e4fc2848946525a26489098, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1584595674
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1584595672}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.377092, y: -2.4997225, z: 2.5791798}
+  m_LocalScale: {x: 10.389, y: 16.242, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1584595675
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1584595672}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -0.32410312, y: -0.43948758}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.35179377, y: 0.12102488}
+  m_EdgeRadius: 0
+--- !u!1001 &1602809969
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080085863366972330, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_Name
+      value: Enemy1 (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.073547
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 18.616657
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+--- !u!1 &1613609061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1613609062}
+  - component: {fileID: 1613609063}
+  m_Layer: 0
+  m_Name: Ice_Top_26_small_R_0001 (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1613609062
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613609061}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 48.38269, y: 37.779377, z: 2.5791798}
+  m_LocalScale: {x: -13.941999, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1613609063
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613609061}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: d3724c7a7e4fc2848946525a26489098, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1664511228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1664511229}
+  - component: {fileID: 1664511230}
+  m_Layer: 6
+  m_Name: Ground1 (4)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1664511229
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664511228}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.674065, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1664511230
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664511228}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1665319721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1665319724}
+  - component: {fileID: 1665319723}
+  - component: {fileID: 1665319722}
+  m_Layer: 5
+  m_Name: TimerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1665319722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665319721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 01:00
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4280746239
+  m_fontColor: {r: 1, g: 0, b: 0.15438032, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1665319723
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665319721}
+  m_CullTransparentMesh: 1
+--- !u!224 &1665319724
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665319721}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1487661379}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 320, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1705116658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 56108361573644348, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.93
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2378838849639834031, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.85
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6234262203523256584, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22.35
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 27.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 29.67
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects:
+    - {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    - {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1705116660}
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1 &1705116659 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+  m_PrefabInstance: {fileID: 1705116658}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &1705116660
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1705116659}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 14.059162, y: 0.55272067}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 29.07769, y: 0.7602656}
+  m_EdgeRadius: 0
+--- !u!1 &1715088110
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1715088113}
+  - component: {fileID: 1715088112}
+  - component: {fileID: 1715088111}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1715088111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1715088110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
+--- !u!114 &1715088112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1715088110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1715088113
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1715088110}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1746848500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1746848502}
+  - component: {fileID: 1746848501}
+  m_Layer: 0
+  m_Name: Ice_Top_26_big_R_0001 (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1746848501
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746848500}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 2335c684b118c804290e36fa1f3d8c3c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1746848502
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1746848500}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 66.36269, y: -4.2616224, z: 2.5791798}
+  m_LocalScale: {x: -10.454, y: 12.678244, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1779223837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1779223840}
+  - component: {fileID: 1779223839}
+  - component: {fileID: 1779223838}
+  - component: {fileID: 1779223842}
+  - component: {fileID: 1779223841}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1779223838
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779223837}
+  m_Enabled: 1
+--- !u!20 &1779223839
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779223837}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 10
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1779223840
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779223837}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.03651619, y: 3.97, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1779223841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779223837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!114 &1779223842
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1779223837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1e0fc4eecbf8d47b07824615782753, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 1425040216}
+  baseYOffset: 8.2
+  minX: 1.3
+  transitionSpeed: 1
+--- !u!1 &1801098925
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1801098926}
+  m_Layer: 0
+  m_Name: Ice
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1801098926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1801098925}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.537308, y: 4.8206224, z: -2.5791798}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 302439603}
+  - {fileID: 1569588821}
+  - {fileID: 1267993514}
+  - {fileID: 1584595674}
+  - {fileID: 16832509}
+  - {fileID: 1746848502}
+  - {fileID: 1118944967}
+  - {fileID: 1980502035}
+  - {fileID: 896794832}
+  - {fileID: 133092205}
+  - {fileID: 1906906670}
+  - {fileID: 1548924851}
+  - {fileID: 1476134716}
+  - {fileID: 1512006286}
+  - {fileID: 680013820}
+  - {fileID: 1494014523}
+  - {fileID: 1613609062}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1882207025
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1882207026}
+  - component: {fileID: 1882207027}
+  m_Layer: 6
+  m_Name: Ground1 (6)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1882207026
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882207025}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 13.55, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1882207027
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882207025}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1897798342
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1897798343}
+  - component: {fileID: 1897798345}
+  - component: {fileID: 1897798344}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1897798343
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897798342}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1990326612}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.6534, y: -0.6533}
+  m_SizeDelta: {x: 968.8866, y: 540.3229}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1897798344
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897798342}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5411765}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1897798345
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897798342}
+  m_CullTransparentMesh: 1
+--- !u!1 &1906906668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1906906670}
+  - component: {fileID: 1906906669}
+  m_Layer: 0
+  m_Name: Ice_Top_26_big_R_0001 (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1906906669
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1906906668}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 2335c684b118c804290e36fa1f3d8c3c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1906906670
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1906906668}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 30.34769, y: -0.60062265, z: 2.5791798}
+  m_LocalScale: {x: 21.369015, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1959972122
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1080085863366972330, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_Name
+      value: Enemy1 (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32.627308
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 26.862413
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4568291841997186324, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 040c1da4e1b3cd44da706167956280d4, type: 3}
+--- !u!1 &1980502033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1980502035}
+  - component: {fileID: 1980502034}
+  m_Layer: 0
+  m_Name: Ice_Bot_spikes_0001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1980502034
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1980502033}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: d284f359f900b004aacb1ec1ebfcc356, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1980502035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1980502033}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 15.969992, y: 17.87938, z: 2.5791798}
+  m_LocalScale: {x: 14.215557, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1801098926}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1990326611
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1990326612}
+  m_Layer: 5
+  m_Name: PauseMenuPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1990326612
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1990326611}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1897798343}
+  - {fileID: 1528382389}
+  - {fileID: 392380339}
+  - {fileID: 840750267}
+  - {fileID: 1458788515}
+  - {fileID: 808651317}
+  m_Father: {fileID: 1071931639}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2009565553
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2009565554}
+  - component: {fileID: 2009565555}
+  m_Layer: 6
+  m_Name: Ground1 (2)
+  m_TagString: Ground
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2009565554
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009565553}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.22121096, y: 0, z: 0}
+  m_LocalScale: {x: 0.6835378, y: 0.6835378, z: 0.6835378}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 594608853}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2009565555
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009565553}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: -1
+  m_Sprite: {fileID: 21300000, guid: f7ae4e5931263c54c9cbb010560ebe15, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 4.01, y: 3.76}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1001 &2127150265
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2824562162200278768, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_Name
+      value: InputHandler
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.974145
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.369895
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.08996085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3039750163081233282, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: speed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: launcher
+      value: 
+      objectReference: {fileID: 1417105288}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: movement
+      value: 
+      objectReference: {fileID: 1425040211}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: jumpHeight
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: playerBody
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: groundCheck
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: groundCheckRadius
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+      propertyPath: groundLayer.m_Bits
+      value: 64
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+--- !u!114 &2127150266 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3820494013843258422, guid: 901a176383c7e194aaafa2aa799124c0, type: 3}
+  m_PrefabInstance: {fileID: 2127150265}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f71135b90d8d364a8f6412500a9e0b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &7267992789748219869
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 91828045687261952, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 136652864866927096, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850377
+      objectReference: {fileID: 0}
+    - target: {fileID: 295906933737386793, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519035
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394711
+      objectReference: {fileID: 0}
+    - target: {fileID: 480416464976097646, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973558
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 543228523970817161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 622622970871354019, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 630322503140766818, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 701784189046151957, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: Ground
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 782928247950293158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127634
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166912
+      objectReference: {fileID: 0}
+    - target: {fileID: 798008950836961929, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 914904860274855941, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: ground
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 920687729480344889, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939098
+      objectReference: {fileID: 0}
+    - target: {fileID: 1014967175683252151, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695498
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1102163763960999809, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285037450347763683, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1342631737760004024, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1344869875265717997, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Name
+      value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1435328870741280388, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1598006784676271140, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.383963
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 1600636231783906571, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939094
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754756438345864835, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954622
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2072848423551709610, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2366573109719777273, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2391564761494705194, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2566195989508856218, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2795164095471105216, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166914
+      objectReference: {fileID: 0}
+    - target: {fileID: 2980581449598446743, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.068345785
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3021770384966149597, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939085
+      objectReference: {fileID: 0}
+    - target: {fileID: 3130728140797137735, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056954324
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622547
+      objectReference: {fileID: 0}
+    - target: {fileID: 3177178503604832935, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127396
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3189158634418757852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3210968612826973324, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.415281
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3320083495159029158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3503677129329864091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850358
+      objectReference: {fileID: 0}
+    - target: {fileID: 3537102148453996585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.10251805
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 3594555658490652132, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973665
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 3953794456026862585, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112728
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4045798700564250287, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143676273506941864, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4144821233118215185, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4286089653929650430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4341589043389740430, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4421642024798756933, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4508433872316210484, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4537524239581172618, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 4578194485253195205, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973689
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4701851085438875577, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4739202870286200236, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4858799875627773528, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4903400229082592127, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043081402915935139, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973671
+      objectReference: {fileID: 0}
+    - target: {fileID: 5114439566517658051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19.417202
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5187250799533104105, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.062255
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487775802684923384, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127336
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593326622583206328, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973623
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394733
+      objectReference: {fileID: 0}
+    - target: {fileID: 5627607900116136143, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973692
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 5702182908565867868, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127515
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5794292039794931091, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0850384
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836255085202708088, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.102519244
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394735
+      objectReference: {fileID: 0}
+    - target: {fileID: 5869369133214742684, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797368
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5898868820134504980, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5914809126167834480, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 5994457719112354303, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.039473
+      objectReference: {fileID: 0}
+    - target: {fileID: 6212184361671533707, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.07973659
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.39
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.4966512
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6373691368386010691, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622551
+      objectReference: {fileID: 0}
+    - target: {fileID: 6396863695128687017, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.091127545
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6545142215443570158, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6635145718495718594, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6957058443390431996, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005113836394698622, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.05695373
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7224130195361871369, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7234272994110641403, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7417586101686655161, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7489192964217139008, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.9939076
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.056953847
+      objectReference: {fileID: 0}
+    - target: {fileID: 7544550832588921530, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7609407236471199534, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7635516906914432836, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0166907
+      objectReference: {fileID: 0}
+    - target: {fileID: 7697077291585881366, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.06834549
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959065729677916852, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 7959226505434956329, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 1.971127
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017475531610796908, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.04556358
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384477249888392248, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8627516473312752769, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8637854348285663954, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0622542
+      objectReference: {fileID: 0}
+    - target: {fileID: 8659843463104688911, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.09112719
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Size.x
+      value: 2.0394723
+      objectReference: {fileID: 0}
+    - target: {fileID: 8760882549538953575, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Offset.x
+      value: 0.0797362
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8801810722740223699, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8932556828882452968, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 8961962973452080326, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 9155931006181088051, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+      propertyPath: m_TagString
+      value: block
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5274eebaeaae94ed4b97b93f56910f9a, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1779223840}
+  - {fileID: 1519090610}
+  - {fileID: 594608853}
+  - {fileID: 7267992789748219869}
+  - {fileID: 104387451}
+  - {fileID: 523421564}
+  - {fileID: 1122101262}
+  - {fileID: 1081612221}
+  - {fileID: 468103844}
+  - {fileID: 669912634}
+  - {fileID: 1386625551}
+  - {fileID: 1053036498}
+  - {fileID: 596899055}
+  - {fileID: 1705116658}
+  - {fileID: 388981801}
+  - {fileID: 1801098926}
+  - {fileID: 816364924}
+  - {fileID: 1071931639}
+  - {fileID: 1715088113}
+  - {fileID: 2127150265}
+  - {fileID: 1425040208}
+  - {fileID: 998851728}
+  - {fileID: 974160795}
+  - {fileID: 545146432}
+  - {fileID: 638369958}
+  - {fileID: 1050653820}
+  - {fileID: 1556547811}
+  - {fileID: 898002497}
+  - {fileID: 1602809969}
+  - {fileID: 1959972122}
+  - {fileID: 963250250}
+  - {fileID: 961005065}

--- a/Assets/Scenes/Level1v1Audio.unity.meta
+++ b/Assets/Scenes/Level1v1Audio.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 70358d524f72846d68add4778f4c9dd0
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description 
Duplicated the Level1v1 scene to create Level1v1Audio, which now includes the `AudioManager` setup used in Level2v2Audio. This allows consistent ambient audio playback and sound effects starting from Level 1. Also updated the `nextSceneName` in the TimerManager within Level1v1Audio to point to "Level2v2", ensuring correct progression to the next level.

# Types of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### I have manually tested the following scenarios, and all tests pass:
1. Ambient sound plays correctly in Level1v1Audio via the AudioManager.
2. Transition to Level2v2 functions as expected after destroying the checkpoint.
3. TimerManager correctly references and loads the updated next scene (Level2v2).
4. AudioManager persists and avoids duplication across scene loads.

# Checklist:
- [x] I have performed a self-review of the code and scene setup.
- [x] My implementation generated no new warnings or errors.
- [x] The AudioManager was not duplicated when transitioning scenes.
- [x] Level1v1Audio is correctly linked to Level2v2.